### PR TITLE
feat: DailyMemo 앱 구현 (SwiftUI + SwiftData MVVM)

### DIFF
--- a/.claude/hooks/swift-commit-guard.sh
+++ b/.claude/hooks/swift-commit-guard.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse(Bash) Hook
+# git commit 전 Swift 코드 품질 자동 검사
+#
+# 검사 항목:
+#   1. main 브랜치 직접 커밋 차단
+#   2. 스테이징된 .swift 파일의 print() 사용 검사
+
+set -uo pipefail
+
+# ── stdin 에서 tool call JSON 수신 ─────────────────────────────────────────
+input=$(cat)
+
+# git commit 명령이 아니면 즉시 통과
+echo "$input" | grep -q '"git commit' || exit 0
+
+# ── 1. main 브랜치 직접 커밋 차단 ─────────────────────────────────────────
+branch=$(git branch --show-current 2>/dev/null || echo "")
+if [ "$branch" = "main" ]; then
+  echo '{"block":true,"message":"main 브랜치 직접 커밋 불가 — feature 브랜치를 사용하세요."}' >&2
+  exit 2
+fi
+
+# ── 2. 스테이징된 Swift 파일에서 print() 검사 ─────────────────────────────
+staged=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null \
+         | grep '\.swift$' || true)
+
+# 스테이징된 Swift 파일 없으면 통과
+[ -z "$staged" ] && exit 0
+
+print_hits=$(echo "$staged" | xargs grep -l 'print(' 2>/dev/null || true)
+if [ -n "$print_hits" ]; then
+  files=$(echo "$print_hits" | tr '\n' ',' | sed 's/,$//')
+  echo "{\"block\":true,\"message\":\"커밋 불가 — print() 발견: $files\"}" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "autoUpdatesChannel": "latest",
+  "model": "claude-sonnet-4-6",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [{
+          "type": "command",
+          "command": "[ \"$(git branch --show-current)\" != \"main\" ] || { echo '{\"block\":true,\"message\":\"main 브랜치 수정 금지\"}' >&2; exit 2; }",
+          "timeout": 5
+        }]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [{
+          "type": "command",
+          "command": "bash \"$HOME/.claude/hooks/swift-commit-guard.sh\"",
+          "timeout": 15
+        }]
+      }
+    ]
+  }
+}

--- a/DailyMemo/CLAUDE.md
+++ b/DailyMemo/CLAUDE.md
@@ -27,32 +27,58 @@ Claude Code가 이 프로젝트에서 작업할 때 참조하는 가이드입니
 
 ## 디렉토리 구조
 
-```
 DailyMemo/
-├── DailyMemoApp.swift
-├── Domain/Models/Memo.swift
+├── App/
+│   └── DailyMemoApp.swift
+├── Domain/
+│   ├── Models/
+│   │   ├── Memo.swift
+│   │   └── Category.swift
+│   └── UseCases/
+│       ├── MemoUseCaseProtocol.swift
+│       └── MemoUseCase.swift
+├── Data/
+│   └── Repositories/
+│       ├── MemoRepositoryProtocol.swift
+│       └── MemoRepository.swift
 ├── Presentation/
 │   ├── MemoList/
+│   │   ├── MemoListView.swift
+│   │   └── MemoListViewModel.swift
 │   ├── MemoEdit/
-│   ├── Extensions/Color+Hex.swift
+│   │   ├── MemoEditView.swift
+│   │   └── MemoEditViewModel.swift
 │   └── Components/
-└── DailyMemoTests/
-```
+└── Resources/
+    └── Assets.xcassets
+
+---
+
+## 아키텍처 규칙
+
+레이어 의존성: Presentation → Domain ← Data
+
+- Presentation: ViewModel은 UseCase 프로토콜에만 의존
+- Domain: 순수 Swift — UIKit·SwiftUI·SwiftData import 없음
+- Data: Repository가 SwiftData ModelContext를 소유
+- @Observable 매크로 사용 (iOS 17+)
+- @MainActor 명시 필수
 
 ---
 
 ## 코딩 컨벤션
 
-| 규칙 | 세부 사항 |
-|------|----------|
-| 문서 주석 | 모든 `public` / `internal` API에 `///` 필수 |
-| 강제 언래핑 | `!` 사용 금지 |
-| print 디버깅 | 커밋에 `print()` 포함 금지 |
-| 브랜치 | `main`에 직접 커밋 금지 |
+- 모든 public/internal API에 /// 필수
+- 강제 언래핑(!) 사용 금지
+- 커밋에 print() 포함 금지
+- main 브랜치 직접 커밋 금지
+- Domain 레이어에서 SwiftUI·SwiftData import 금지
+- ModelContext는 Environment로 주입, 직접 생성 금지
 
-## DO NOT
-- `main` 브랜치에 직접 커밋하지 않는다
-- 강제 언래핑(`!`) 사용하지 않는다
-- `print()` 를 커밋에 포함하지 않는다
-- ViewModel에서 SwiftData `@Query` 를 사용하지 않는다
-- Domain 레이어에서 SwiftUI를 import하지 않는다
+---
+
+## 빌드 & 테스트
+
+swift build
+swift test
+swiftlint

--- a/DailyMemo/CLAUDE.md
+++ b/DailyMemo/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md — DailyMemo
+
+Claude Code가 이 프로젝트에서 작업할 때 참조하는 가이드입니다.
+
+## 응답 언어
+항상 한국어로 응답한다.
+
+---
+
+## 프로젝트 개요
+
+| 항목 | 내용 |
+|------|------|
+| 앱 이름 | DailyMemo |
+| 플랫폼 | iOS 17+ |
+| UI 프레임워크 | SwiftUI |
+| 영속성 | SwiftData |
+| 아키텍처 | MVVM + Clean Architecture |
+| 최소 배포 타깃 | iOS 17.0 |
+
+### 핵심 기능
+- **메모 CRUD** — 생성 / 조회 / 수정 / 삭제
+- **카테고리** — 메모에 카테고리 태그 부여 및 필터링
+- **검색** — 제목·본문 전문 검색 (SwiftData `#Predicate` 활용)
+
+---
+
+## 디렉토리 구조
+
+```
+DailyMemo/
+├── DailyMemoApp.swift
+├── Domain/Models/Memo.swift
+├── Presentation/
+│   ├── MemoList/
+│   ├── MemoEdit/
+│   ├── Extensions/Color+Hex.swift
+│   └── Components/
+└── DailyMemoTests/
+```
+
+---
+
+## 코딩 컨벤션
+
+| 규칙 | 세부 사항 |
+|------|----------|
+| 문서 주석 | 모든 `public` / `internal` API에 `///` 필수 |
+| 강제 언래핑 | `!` 사용 금지 |
+| print 디버깅 | 커밋에 `print()` 포함 금지 |
+| 브랜치 | `main`에 직접 커밋 금지 |
+
+## DO NOT
+- `main` 브랜치에 직접 커밋하지 않는다
+- 강제 언래핑(`!`) 사용하지 않는다
+- `print()` 를 커밋에 포함하지 않는다
+- ViewModel에서 SwiftData `@Query` 를 사용하지 않는다
+- Domain 레이어에서 SwiftUI를 import하지 않는다

--- a/DailyMemo/DailyMemoApp.swift
+++ b/DailyMemo/DailyMemoApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import SwiftData
+
+/// DailyMemo 앱의 진입점
+@main
+struct DailyMemoApp: App {
+
+    var body: some Scene {
+        WindowGroup {
+            MemoListView()
+        }
+        .modelContainer(for: Memo.self)
+    }
+}

--- a/DailyMemo/DailyMemoTests/MemoEditViewModelTests.swift
+++ b/DailyMemo/DailyMemoTests/MemoEditViewModelTests.swift
@@ -1,0 +1,252 @@
+import Testing
+import SwiftData
+@testable import DailyMemo
+
+@Suite("MemoEditViewModel 테스트")
+@MainActor
+struct MemoEditViewModelTests {
+
+    private let context: ModelContext
+
+    init() throws {
+        let container = try ModelContainer(
+            for: Memo.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        context = container.mainContext
+    }
+
+    // MARK: - init() 신규 작성
+
+    @Test("신규 초기화: title 과 content 가 빈 문자열")
+    func init_new_emptyFields() {
+        let sut = MemoEditViewModel()
+        #expect(sut.title == "")
+        #expect(sut.content == "")
+    }
+
+    @Test("신규 초기화: 기본 색상이 yellow")
+    func init_new_defaultColorYellow() {
+        let sut = MemoEditViewModel()
+        #expect(sut.selectedColor == .yellow)
+    }
+
+    @Test("신규 초기화: isEditing 이 false, errorMessage 가 nil")
+    func init_new_editingFalseErrorNil() {
+        let sut = MemoEditViewModel()
+        #expect(sut.isEditing == false)
+        #expect(sut.errorMessage == nil)
+    }
+
+    // MARK: - init(memo:) 수정 모드
+
+    @Test("수정 초기화: 기존 메모의 title, content 로 채워짐")
+    func init_edit_populatesFields() {
+        let memo = Memo(title: "기존 제목", content: "기존 본문")
+        context.insert(memo)
+        let sut = MemoEditViewModel(memo: memo)
+        #expect(sut.title == "기존 제목")
+        #expect(sut.content == "기존 본문")
+    }
+
+    @Test("수정 초기화: isEditing 이 true")
+    func init_edit_isEditingTrue() {
+        let memo = Memo(title: "메모")
+        let sut = MemoEditViewModel(memo: memo)
+        #expect(sut.isEditing == true)
+    }
+
+    @Test("수정 초기화: 메모의 색상으로 채워짐")
+    func init_edit_populatesColor() {
+        let memo = Memo(colorHex: MemoColor.purple.rawValue)
+        let sut = MemoEditViewModel(memo: memo)
+        #expect(sut.selectedColor == .purple)
+    }
+
+    // MARK: - isSaveEnabled
+
+    @Test("제목만 있으면 저장 활성화")
+    func isSaveEnabled_titleOnly_isTrue() {
+        let sut = MemoEditViewModel()
+        sut.title = "제목"
+        #expect(sut.isSaveEnabled == true)
+    }
+
+    @Test("본문만 있으면 저장 활성화")
+    func isSaveEnabled_contentOnly_isTrue() {
+        let sut = MemoEditViewModel()
+        sut.content = "본문"
+        #expect(sut.isSaveEnabled == true)
+    }
+
+    @Test("제목과 본문 모두 비어 있으면 저장 비활성화")
+    func isSaveEnabled_bothEmpty_isFalse() {
+        let sut = MemoEditViewModel()
+        #expect(sut.isSaveEnabled == false)
+    }
+
+    @Test("공백·개행만 있으면 저장 비활성화")
+    func isSaveEnabled_whitespaceOnly_isFalse() {
+        let sut = MemoEditViewModel()
+        sut.title   = "   "
+        sut.content = "\n\t"
+        #expect(sut.isSaveEnabled == false)
+    }
+
+    @Test("제목과 본문 모두 있으면 저장 활성화")
+    func isSaveEnabled_bothFilled_isTrue() {
+        let sut = MemoEditViewModel()
+        sut.title   = "제목"
+        sut.content = "본문"
+        #expect(sut.isSaveEnabled == true)
+    }
+
+    // MARK: - save — 신규
+
+    @Test("신규 저장 후 컨텍스트에서 fetch 됨")
+    func save_new_insertedToContext() throws {
+        let sut = MemoEditViewModel()
+        sut.title   = "새 메모"
+        sut.content = "내용"
+        sut.save(context: context)
+
+        let results = try context.fetch(FetchDescriptor<Memo>())
+        #expect(results.count == 1)
+        #expect(results.first?.title == "새 메모")
+    }
+
+    @Test("신규 저장 시 선택 색상이 저장됨")
+    func save_new_colorSaved() throws {
+        let sut = MemoEditViewModel()
+        sut.title         = "메모"
+        sut.selectedColor = .blue
+        sut.save(context: context)
+
+        let results = try context.fetch(FetchDescriptor<Memo>())
+        #expect(results.first?.colorHex == MemoColor.blue.rawValue)
+    }
+
+    @Test("isSaveEnabled 가 false 이면 저장되지 않음")
+    func save_new_disabledDoesNotSave() throws {
+        let sut = MemoEditViewModel()
+        sut.save(context: context)
+
+        let results = try context.fetch(FetchDescriptor<Memo>())
+        #expect(results.isEmpty)
+    }
+
+    @Test("신규 저장 성공 시 errorMessage 가 nil")
+    func save_new_errorMessageNilOnSuccess() {
+        let sut = MemoEditViewModel()
+        sut.title = "메모"
+        sut.save(context: context)
+        #expect(sut.errorMessage == nil)
+    }
+
+    // MARK: - save — 수정
+
+    @Test("수정 저장 시 기존 메모의 title, content 가 업데이트됨")
+    func save_edit_updatesTitleAndContent() {
+        let memo = Memo(title: "원본", content: "원본 내용")
+        context.insert(memo)
+
+        let sut = MemoEditViewModel(memo: memo)
+        sut.title   = "수정됨"
+        sut.content = "수정된 내용"
+        sut.save(context: context)
+
+        #expect(memo.title   == "수정됨")
+        #expect(memo.content == "수정된 내용")
+    }
+
+    @Test("수정 저장 시 색상이 업데이트됨")
+    func save_edit_updatesColor() {
+        let memo = Memo(colorHex: MemoColor.yellow.rawValue)
+        context.insert(memo)
+
+        let sut = MemoEditViewModel(memo: memo)
+        sut.title         = "메모"
+        sut.selectedColor = .purple
+        sut.save(context: context)
+
+        #expect(memo.colorHex == MemoColor.purple.rawValue)
+    }
+
+    @Test("수정 저장 시 updatedAt 이 저장 이전 시각 이상으로 갱신됨")
+    func save_edit_updatesTimestamp() {
+        let before = Date()
+        let memo = Memo(title: "테스트")
+        context.insert(memo)
+
+        let sut = MemoEditViewModel(memo: memo)
+        sut.title = "변경"
+        sut.save(context: context)
+
+        #expect(memo.updatedAt >= before)
+    }
+
+    @Test("수정 저장 시 새 메모가 추가되지 않음")
+    func save_edit_noNewMemoAdded() throws {
+        let memo = Memo(title: "기존")
+        context.insert(memo)
+
+        let sut = MemoEditViewModel(memo: memo)
+        sut.title = "수정"
+        sut.save(context: context)
+
+        let results = try context.fetch(FetchDescriptor<Memo>())
+        #expect(results.count == 1)
+    }
+
+    // MARK: - delete
+
+    @Test("수정 모드에서 delete 호출 시 메모가 삭제됨")
+    func delete_edit_removesFromContext() throws {
+        let memo = Memo(title: "삭제 대상")
+        context.insert(memo)
+
+        let sut = MemoEditViewModel(memo: memo)
+        sut.delete(context: context)
+
+        let results = try context.fetch(FetchDescriptor<Memo>())
+        #expect(results.isEmpty)
+    }
+
+    @Test("신규 작성 모드에서 delete 호출 시 아무것도 삭제되지 않음")
+    func delete_new_doesNothing() throws {
+        let memo = Memo(title: "유지됨")
+        context.insert(memo)
+
+        let sut = MemoEditViewModel()
+        sut.delete(context: context)
+
+        let results = try context.fetch(FetchDescriptor<Memo>())
+        #expect(results.count == 1)
+    }
+
+    @Test("delete 성공 시 errorMessage 가 nil")
+    func delete_errorMessageNilOnSuccess() {
+        let memo = Memo(title: "삭제")
+        context.insert(memo)
+
+        let sut = MemoEditViewModel(memo: memo)
+        sut.delete(context: context)
+
+        #expect(sut.errorMessage == nil)
+    }
+
+    @Test("delete 는 지정한 메모만 삭제하고 나머지는 유지됨")
+    func delete_keepsOtherMemos() throws {
+        let target = Memo(title: "삭제 대상")
+        let other  = Memo(title: "유지됨")
+        context.insert(target)
+        context.insert(other)
+
+        let sut = MemoEditViewModel(memo: target)
+        sut.delete(context: context)
+
+        let results = try context.fetch(FetchDescriptor<Memo>())
+        #expect(results.count == 1)
+        #expect(results.first?.title == "유지됨")
+    }
+}

--- a/DailyMemo/DailyMemoTests/MemoEditViewModelTests.swift
+++ b/DailyMemo/DailyMemoTests/MemoEditViewModelTests.swift
@@ -19,20 +19,20 @@ struct MemoEditViewModelTests {
     // MARK: - init() 신규 작성
 
     @Test("신규 초기화: title 과 content 가 빈 문자열")
-    func init_new_emptyFields() {
+    func init_신규_빈문자열초기화() {
         let sut = MemoEditViewModel()
         #expect(sut.title == "")
         #expect(sut.content == "")
     }
 
     @Test("신규 초기화: 기본 색상이 yellow")
-    func init_new_defaultColorYellow() {
+    func init_신규_기본색상yellow() {
         let sut = MemoEditViewModel()
         #expect(sut.selectedColor == .yellow)
     }
 
     @Test("신규 초기화: isEditing 이 false, errorMessage 가 nil")
-    func init_new_editingFalseErrorNil() {
+    func init_신규_isEditing과errorMessage() {
         let sut = MemoEditViewModel()
         #expect(sut.isEditing == false)
         #expect(sut.errorMessage == nil)
@@ -41,7 +41,7 @@ struct MemoEditViewModelTests {
     // MARK: - init(memo:) 수정 모드
 
     @Test("수정 초기화: 기존 메모의 title, content 로 채워짐")
-    func init_edit_populatesFields() {
+    func init_수정_기존메모값으로초기화() {
         let memo = Memo(title: "기존 제목", content: "기존 본문")
         context.insert(memo)
         let sut = MemoEditViewModel(memo: memo)
@@ -50,14 +50,14 @@ struct MemoEditViewModelTests {
     }
 
     @Test("수정 초기화: isEditing 이 true")
-    func init_edit_isEditingTrue() {
+    func init_수정_isEditingTrue() {
         let memo = Memo(title: "메모")
         let sut = MemoEditViewModel(memo: memo)
         #expect(sut.isEditing == true)
     }
 
     @Test("수정 초기화: 메모의 색상으로 채워짐")
-    func init_edit_populatesColor() {
+    func init_수정_색상이메모색상으로초기화() {
         let memo = Memo(colorHex: MemoColor.purple.rawValue)
         let sut = MemoEditViewModel(memo: memo)
         #expect(sut.selectedColor == .purple)
@@ -66,27 +66,27 @@ struct MemoEditViewModelTests {
     // MARK: - isSaveEnabled
 
     @Test("제목만 있으면 저장 활성화")
-    func isSaveEnabled_titleOnly_isTrue() {
+    func isSaveEnabled_제목만있으면true() {
         let sut = MemoEditViewModel()
         sut.title = "제목"
         #expect(sut.isSaveEnabled == true)
     }
 
     @Test("본문만 있으면 저장 활성화")
-    func isSaveEnabled_contentOnly_isTrue() {
+    func isSaveEnabled_본문만있으면true() {
         let sut = MemoEditViewModel()
         sut.content = "본문"
         #expect(sut.isSaveEnabled == true)
     }
 
     @Test("제목과 본문 모두 비어 있으면 저장 비활성화")
-    func isSaveEnabled_bothEmpty_isFalse() {
+    func isSaveEnabled_모두비어있으면false() {
         let sut = MemoEditViewModel()
         #expect(sut.isSaveEnabled == false)
     }
 
     @Test("공백·개행만 있으면 저장 비활성화")
-    func isSaveEnabled_whitespaceOnly_isFalse() {
+    func isSaveEnabled_공백개행만있으면false() {
         let sut = MemoEditViewModel()
         sut.title   = "   "
         sut.content = "\n\t"
@@ -94,7 +94,7 @@ struct MemoEditViewModelTests {
     }
 
     @Test("제목과 본문 모두 있으면 저장 활성화")
-    func isSaveEnabled_bothFilled_isTrue() {
+    func isSaveEnabled_모두있으면true() {
         let sut = MemoEditViewModel()
         sut.title   = "제목"
         sut.content = "본문"
@@ -104,7 +104,7 @@ struct MemoEditViewModelTests {
     // MARK: - save — 신규
 
     @Test("신규 저장 후 컨텍스트에서 fetch 됨")
-    func save_new_insertedToContext() throws {
+    func save_신규_컨텍스트에추가됨() throws {
         let sut = MemoEditViewModel()
         sut.title   = "새 메모"
         sut.content = "내용"
@@ -116,7 +116,7 @@ struct MemoEditViewModelTests {
     }
 
     @Test("신규 저장 시 선택 색상이 저장됨")
-    func save_new_colorSaved() throws {
+    func save_신규_선택색상저장됨() throws {
         let sut = MemoEditViewModel()
         sut.title         = "메모"
         sut.selectedColor = .blue
@@ -127,8 +127,8 @@ struct MemoEditViewModelTests {
     }
 
     @Test("isSaveEnabled 가 false 이면 저장되지 않음")
-    func save_new_disabledDoesNotSave() throws {
-        let sut = MemoEditViewModel()
+    func save_신규_isSaveEnabledFalse이면저장안됨() throws {
+        let sut = MemoEditViewModel()   // title, content 모두 비어 있음
         sut.save(context: context)
 
         let results = try context.fetch(FetchDescriptor<Memo>())
@@ -136,7 +136,7 @@ struct MemoEditViewModelTests {
     }
 
     @Test("신규 저장 성공 시 errorMessage 가 nil")
-    func save_new_errorMessageNilOnSuccess() {
+    func save_신규_성공시errorMessageNil() {
         let sut = MemoEditViewModel()
         sut.title = "메모"
         sut.save(context: context)
@@ -146,7 +146,7 @@ struct MemoEditViewModelTests {
     // MARK: - save — 수정
 
     @Test("수정 저장 시 기존 메모의 title, content 가 업데이트됨")
-    func save_edit_updatesTitleAndContent() {
+    func save_수정_제목내용업데이트() {
         let memo = Memo(title: "원본", content: "원본 내용")
         context.insert(memo)
 
@@ -160,7 +160,7 @@ struct MemoEditViewModelTests {
     }
 
     @Test("수정 저장 시 색상이 업데이트됨")
-    func save_edit_updatesColor() {
+    func save_수정_색상업데이트() {
         let memo = Memo(colorHex: MemoColor.yellow.rawValue)
         context.insert(memo)
 
@@ -173,7 +173,7 @@ struct MemoEditViewModelTests {
     }
 
     @Test("수정 저장 시 updatedAt 이 저장 이전 시각 이상으로 갱신됨")
-    func save_edit_updatesTimestamp() {
+    func save_수정_updatedAt갱신됨() {
         let before = Date()
         let memo = Memo(title: "테스트")
         context.insert(memo)
@@ -186,7 +186,7 @@ struct MemoEditViewModelTests {
     }
 
     @Test("수정 저장 시 새 메모가 추가되지 않음")
-    func save_edit_noNewMemoAdded() throws {
+    func save_수정_새메모추가안됨() throws {
         let memo = Memo(title: "기존")
         context.insert(memo)
 
@@ -201,7 +201,7 @@ struct MemoEditViewModelTests {
     // MARK: - delete
 
     @Test("수정 모드에서 delete 호출 시 메모가 삭제됨")
-    func delete_edit_removesFromContext() throws {
+    func delete_수정모드에서삭제됨() throws {
         let memo = Memo(title: "삭제 대상")
         context.insert(memo)
 
@@ -213,11 +213,11 @@ struct MemoEditViewModelTests {
     }
 
     @Test("신규 작성 모드에서 delete 호출 시 아무것도 삭제되지 않음")
-    func delete_new_doesNothing() throws {
+    func delete_신규모드에서는아무것도삭제안됨() throws {
         let memo = Memo(title: "유지됨")
         context.insert(memo)
 
-        let sut = MemoEditViewModel()
+        let sut = MemoEditViewModel()   // originalMemo = nil
         sut.delete(context: context)
 
         let results = try context.fetch(FetchDescriptor<Memo>())
@@ -225,7 +225,7 @@ struct MemoEditViewModelTests {
     }
 
     @Test("delete 성공 시 errorMessage 가 nil")
-    func delete_errorMessageNilOnSuccess() {
+    func delete_성공시errorMessageNil() {
         let memo = Memo(title: "삭제")
         context.insert(memo)
 
@@ -236,7 +236,7 @@ struct MemoEditViewModelTests {
     }
 
     @Test("delete 는 지정한 메모만 삭제하고 나머지는 유지됨")
-    func delete_keepsOtherMemos() throws {
+    func delete_지정메모만삭제() throws {
         let target = Memo(title: "삭제 대상")
         let other  = Memo(title: "유지됨")
         context.insert(target)

--- a/DailyMemo/DailyMemoTests/MemoListViewModelTests.swift
+++ b/DailyMemo/DailyMemoTests/MemoListViewModelTests.swift
@@ -1,0 +1,207 @@
+import Testing
+import SwiftData
+@testable import DailyMemo
+
+@Suite("MemoListViewModel 테스트")
+@MainActor
+struct MemoListViewModelTests {
+
+    private let sut: MemoListViewModel
+    private let context: ModelContext
+
+    init() throws {
+        let container = try ModelContainer(
+            for: Memo.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        context = container.mainContext
+        sut = MemoListViewModel()
+    }
+
+    // MARK: - 초기 상태
+
+    @Test("초기 searchQuery 가 빈 문자열")
+    func init_searchQuery() {
+        #expect(sut.searchQuery == "")
+    }
+
+    @Test("초기 selectedColorFilter 가 nil")
+    func init_selectedColorFilter() {
+        #expect(sut.selectedColorFilter == nil)
+    }
+
+    @Test("초기 Sheet 상태 — isAddingMemo false, editingMemo nil")
+    func init_sheetState() {
+        #expect(sut.isAddingMemo == false)
+        #expect(sut.editingMemo == nil)
+    }
+
+    // MARK: - filteredMemos — 검색어
+
+    @Test("검색어 없으면 전체 메모 반환")
+    func filteredMemos_noQuery_returnsAll() {
+        let memos = makeMemos(["A", "B", "C"])
+        #expect(sut.filteredMemos(memos).count == 3)
+    }
+
+    @Test("빈 배열 입력 시 빈 배열 반환")
+    func filteredMemos_emptyInput_returnsEmpty() {
+        #expect(sut.filteredMemos([]).isEmpty)
+    }
+
+    @Test("제목으로 검색하면 일치하는 메모만 반환")
+    func filteredMemos_titleSearch() {
+        let memos = makeMemos(["사과 주스", "바나나", "사과 케이크"])
+        sut.searchQuery = "사과"
+        #expect(sut.filteredMemos(memos).count == 2)
+    }
+
+    @Test("본문으로 검색하면 일치하는 메모만 반환")
+    func filteredMemos_contentSearch() {
+        let a = Memo(title: "제목1", content: "맑은 날씨")
+        let b = Memo(title: "제목2", content: "비가 온다")
+        sut.searchQuery = "맑은"
+        let result = sut.filteredMemos([a, b])
+        #expect(result.count == 1)
+        #expect(result.first?.title == "제목1")
+    }
+
+    @Test("검색은 대소문자를 무시한다")
+    func filteredMemos_caseInsensitive() {
+        let memos = [Memo(title: "Hello World")]
+        sut.searchQuery = "hello"
+        #expect(sut.filteredMemos(memos).count == 1)
+    }
+
+    @Test("검색 결과 없으면 빈 배열 반환")
+    func filteredMemos_noResults_returnsEmpty() {
+        let memos = makeMemos(["사과", "바나나"])
+        sut.searchQuery = "포도"
+        #expect(sut.filteredMemos(memos).isEmpty)
+    }
+
+    @Test("공백만 있는 검색어는 전체 반환")
+    func filteredMemos_whitespaceQuery_returnsAll() {
+        let memos = makeMemos(["A", "B"])
+        sut.searchQuery = "   "
+        #expect(sut.filteredMemos(memos).count == 2)
+    }
+
+    // MARK: - filteredMemos — 색상 필터
+
+    @Test("색상 필터 적용 시 해당 색상 메모만 반환")
+    func filteredMemos_colorFilter_returnsMatching() {
+        let memos = [
+            Memo(title: "노랑", colorHex: MemoColor.yellow.rawValue),
+            Memo(title: "분홍", colorHex: MemoColor.pink.rawValue),
+            Memo(title: "파랑", colorHex: MemoColor.blue.rawValue),
+        ]
+        sut.selectedColorFilter = .yellow
+        let result = sut.filteredMemos(memos)
+        #expect(result.count == 1)
+        #expect(result.first?.title == "노랑")
+    }
+
+    @Test("색상 필터 nil 이면 전체 메모 반환")
+    func filteredMemos_nilColorFilter_returnsAll() {
+        let memos = [
+            Memo(title: "A", colorHex: MemoColor.yellow.rawValue),
+            Memo(title: "B", colorHex: MemoColor.green.rawValue),
+        ]
+        sut.selectedColorFilter = nil
+        #expect(sut.filteredMemos(memos).count == 2)
+    }
+
+    @Test("검색어 + 색상 필터 동시 적용")
+    func filteredMemos_combinedFilters() {
+        let memos = [
+            Memo(title: "노랑 메모",  colorHex: MemoColor.yellow.rawValue),
+            Memo(title: "파랑 메모",  colorHex: MemoColor.blue.rawValue),
+            Memo(title: "노랑 다른것", colorHex: MemoColor.yellow.rawValue),
+        ]
+        sut.selectedColorFilter = .yellow
+        sut.searchQuery = "메모"
+        let result = sut.filteredMemos(memos)
+        #expect(result.count == 1)
+        #expect(result.first?.title == "노랑 메모")
+    }
+
+    // MARK: - toggleColorFilter
+
+    @Test("색상 선택 시 selectedColorFilter 에 설정됨")
+    func toggleColorFilter_setsColor() {
+        sut.toggleColorFilter(.blue)
+        #expect(sut.selectedColorFilter == .blue)
+    }
+
+    @Test("선택된 색상 재탭 시 nil 로 해제됨")
+    func toggleColorFilter_retap_setsNil() {
+        sut.toggleColorFilter(.blue)
+        sut.toggleColorFilter(.blue)
+        #expect(sut.selectedColorFilter == nil)
+    }
+
+    @Test("다른 색상 탭 시 새 색상으로 변경됨")
+    func toggleColorFilter_differentColor_changes() {
+        sut.toggleColorFilter(.blue)
+        sut.toggleColorFilter(.green)
+        #expect(sut.selectedColorFilter == .green)
+    }
+
+    @Test("MemoColor 전체 케이스 순차 선택 가능")
+    func toggleColorFilter_allCases() {
+        for color in MemoColor.allCases {
+            sut.selectedColorFilter = nil
+            sut.toggleColorFilter(color)
+            #expect(sut.selectedColorFilter == color)
+        }
+    }
+
+    // MARK: - deleteMemo
+
+    @Test("deleteMemo 호출 후 해당 메모가 fetch 결과에서 사라짐")
+    func deleteMemo_removesFromContext() throws {
+        let memo = Memo(title: "삭제 대상")
+        context.insert(memo)
+        try context.save()
+
+        sut.deleteMemo(memo, context: context)
+
+        let results = try context.fetch(FetchDescriptor<Memo>())
+        #expect(results.isEmpty)
+    }
+
+    @Test("deleteMemo 는 지정한 메모만 삭제하고 나머지는 유지됨")
+    func deleteMemo_keepsOthers() throws {
+        let target = Memo(title: "삭제")
+        let other  = Memo(title: "유지")
+        context.insert(target)
+        context.insert(other)
+        try context.save()
+
+        sut.deleteMemo(target, context: context)
+
+        let results = try context.fetch(FetchDescriptor<Memo>())
+        #expect(results.count == 1)
+        #expect(results.first?.title == "유지")
+    }
+
+    @Test("여러 메모 중 특정 메모만 삭제됨")
+    func deleteMemo_specificAmongMany() throws {
+        let memos = (1...3).map { Memo(title: "메모 \($0)") }
+        memos.forEach { context.insert($0) }
+        try context.save()
+
+        sut.deleteMemo(memos[1], context: context)
+
+        let results = try context.fetch(FetchDescriptor<Memo>())
+        #expect(results.count == 2)
+        #expect(!results.contains { $0.title == "메모 2" })
+    }
+
+    // MARK: - Helpers
+
+    private func makeMemos(_ titles: [String]) -> [Memo] {
+        titles.map { Memo(title: $0, content: "") }
+    }
+}

--- a/DailyMemo/DailyMemoTests/MemoListViewModelTests.swift
+++ b/DailyMemo/DailyMemoTests/MemoListViewModelTests.swift
@@ -21,17 +21,17 @@ struct MemoListViewModelTests {
     // MARK: - 초기 상태
 
     @Test("초기 searchQuery 가 빈 문자열")
-    func init_searchQuery() {
+    func 초기_searchQuery가빈문자열() {
         #expect(sut.searchQuery == "")
     }
 
     @Test("초기 selectedColorFilter 가 nil")
-    func init_selectedColorFilter() {
+    func 초기_selectedColorFilter가nil() {
         #expect(sut.selectedColorFilter == nil)
     }
 
     @Test("초기 Sheet 상태 — isAddingMemo false, editingMemo nil")
-    func init_sheetState() {
+    func 초기_Sheet상태가모두비활성() {
         #expect(sut.isAddingMemo == false)
         #expect(sut.editingMemo == nil)
     }
@@ -39,25 +39,25 @@ struct MemoListViewModelTests {
     // MARK: - filteredMemos — 검색어
 
     @Test("검색어 없으면 전체 메모 반환")
-    func filteredMemos_noQuery_returnsAll() {
+    func filteredMemos_검색어없으면전체반환() {
         let memos = makeMemos(["A", "B", "C"])
         #expect(sut.filteredMemos(memos).count == 3)
     }
 
     @Test("빈 배열 입력 시 빈 배열 반환")
-    func filteredMemos_emptyInput_returnsEmpty() {
+    func filteredMemos_빈배열입력시빈배열반환() {
         #expect(sut.filteredMemos([]).isEmpty)
     }
 
     @Test("제목으로 검색하면 일치하는 메모만 반환")
-    func filteredMemos_titleSearch() {
+    func filteredMemos_제목검색() {
         let memos = makeMemos(["사과 주스", "바나나", "사과 케이크"])
         sut.searchQuery = "사과"
         #expect(sut.filteredMemos(memos).count == 2)
     }
 
     @Test("본문으로 검색하면 일치하는 메모만 반환")
-    func filteredMemos_contentSearch() {
+    func filteredMemos_본문검색() {
         let a = Memo(title: "제목1", content: "맑은 날씨")
         let b = Memo(title: "제목2", content: "비가 온다")
         sut.searchQuery = "맑은"
@@ -67,21 +67,21 @@ struct MemoListViewModelTests {
     }
 
     @Test("검색은 대소문자를 무시한다")
-    func filteredMemos_caseInsensitive() {
+    func filteredMemos_대소문자무시() {
         let memos = [Memo(title: "Hello World")]
         sut.searchQuery = "hello"
         #expect(sut.filteredMemos(memos).count == 1)
     }
 
     @Test("검색 결과 없으면 빈 배열 반환")
-    func filteredMemos_noResults_returnsEmpty() {
+    func filteredMemos_결과없으면빈배열() {
         let memos = makeMemos(["사과", "바나나"])
         sut.searchQuery = "포도"
         #expect(sut.filteredMemos(memos).isEmpty)
     }
 
     @Test("공백만 있는 검색어는 전체 반환")
-    func filteredMemos_whitespaceQuery_returnsAll() {
+    func filteredMemos_공백검색어는전체반환() {
         let memos = makeMemos(["A", "B"])
         sut.searchQuery = "   "
         #expect(sut.filteredMemos(memos).count == 2)
@@ -90,7 +90,7 @@ struct MemoListViewModelTests {
     // MARK: - filteredMemos — 색상 필터
 
     @Test("색상 필터 적용 시 해당 색상 메모만 반환")
-    func filteredMemos_colorFilter_returnsMatching() {
+    func filteredMemos_색상필터적용() {
         let memos = [
             Memo(title: "노랑", colorHex: MemoColor.yellow.rawValue),
             Memo(title: "분홍", colorHex: MemoColor.pink.rawValue),
@@ -103,7 +103,7 @@ struct MemoListViewModelTests {
     }
 
     @Test("색상 필터 nil 이면 전체 메모 반환")
-    func filteredMemos_nilColorFilter_returnsAll() {
+    func filteredMemos_색상필터nil이면전체반환() {
         let memos = [
             Memo(title: "A", colorHex: MemoColor.yellow.rawValue),
             Memo(title: "B", colorHex: MemoColor.green.rawValue),
@@ -113,7 +113,7 @@ struct MemoListViewModelTests {
     }
 
     @Test("검색어 + 색상 필터 동시 적용")
-    func filteredMemos_combinedFilters() {
+    func filteredMemos_검색어와색상필터복합() {
         let memos = [
             Memo(title: "노랑 메모",  colorHex: MemoColor.yellow.rawValue),
             Memo(title: "파랑 메모",  colorHex: MemoColor.blue.rawValue),
@@ -129,27 +129,27 @@ struct MemoListViewModelTests {
     // MARK: - toggleColorFilter
 
     @Test("색상 선택 시 selectedColorFilter 에 설정됨")
-    func toggleColorFilter_setsColor() {
+    func toggleColorFilter_색상선택() {
         sut.toggleColorFilter(.blue)
         #expect(sut.selectedColorFilter == .blue)
     }
 
     @Test("선택된 색상 재탭 시 nil 로 해제됨")
-    func toggleColorFilter_retap_setsNil() {
+    func toggleColorFilter_재탭시nil로해제() {
         sut.toggleColorFilter(.blue)
         sut.toggleColorFilter(.blue)
         #expect(sut.selectedColorFilter == nil)
     }
 
     @Test("다른 색상 탭 시 새 색상으로 변경됨")
-    func toggleColorFilter_differentColor_changes() {
+    func toggleColorFilter_다른색상으로변경() {
         sut.toggleColorFilter(.blue)
         sut.toggleColorFilter(.green)
         #expect(sut.selectedColorFilter == .green)
     }
 
     @Test("MemoColor 전체 케이스 순차 선택 가능")
-    func toggleColorFilter_allCases() {
+    func toggleColorFilter_모든색상케이스선택가능() {
         for color in MemoColor.allCases {
             sut.selectedColorFilter = nil
             sut.toggleColorFilter(color)
@@ -160,7 +160,7 @@ struct MemoListViewModelTests {
     // MARK: - deleteMemo
 
     @Test("deleteMemo 호출 후 해당 메모가 fetch 결과에서 사라짐")
-    func deleteMemo_removesFromContext() throws {
+    func deleteMemo_삭제후메모가사라짐() throws {
         let memo = Memo(title: "삭제 대상")
         context.insert(memo)
         try context.save()
@@ -172,7 +172,7 @@ struct MemoListViewModelTests {
     }
 
     @Test("deleteMemo 는 지정한 메모만 삭제하고 나머지는 유지됨")
-    func deleteMemo_keepsOthers() throws {
+    func deleteMemo_지정메모만삭제() throws {
         let target = Memo(title: "삭제")
         let other  = Memo(title: "유지")
         context.insert(target)
@@ -187,7 +187,7 @@ struct MemoListViewModelTests {
     }
 
     @Test("여러 메모 중 특정 메모만 삭제됨")
-    func deleteMemo_specificAmongMany() throws {
+    func deleteMemo_여러건중특정메모삭제() throws {
         let memos = (1...3).map { Memo(title: "메모 \($0)") }
         memos.forEach { context.insert($0) }
         try context.save()

--- a/DailyMemo/Domain/Models/Memo.swift
+++ b/DailyMemo/Domain/Models/Memo.swift
@@ -1,0 +1,60 @@
+import SwiftData
+
+// MARK: - MemoColor
+
+/// 포스트잇 배경 색상 팔레트
+enum MemoColor: String, CaseIterable, Codable {
+    case yellow = "FFF176"
+    case pink   = "F48FB1"
+    case blue   = "81D4FA"
+    case green  = "A5D6A7"
+    case purple = "CE93D8"
+
+    /// 접근성 레이블
+    var label: String {
+        switch self {
+        case .yellow: return "노랑"
+        case .pink:   return "분홍"
+        case .blue:   return "하늘"
+        case .green:  return "초록"
+        case .purple: return "보라"
+        }
+    }
+}
+
+// MARK: - Memo
+
+/// 메모 데이터 모델 (SwiftData 엔티티)
+@Model
+final class Memo {
+    /// 고유 식별자
+    var id: UUID
+    /// 제목 (빈 문자열 허용 — "무제" 로 표시)
+    var title: String
+    /// 본문 내용
+    var content: String
+    /// 포스트잇 배경 색상 (`MemoColor.rawValue`)
+    var colorHex: String
+    /// 최초 생성 시각
+    var createdAt: Date
+    /// 마지막 수정 시각
+    var updatedAt: Date
+
+    init(
+        title: String = "",
+        content: String = "",
+        colorHex: String = MemoColor.yellow.rawValue
+    ) {
+        self.id        = UUID()
+        self.title     = title
+        self.content   = content
+        self.colorHex  = colorHex
+        self.createdAt = Date()
+        self.updatedAt = Date()
+    }
+
+    /// 저장된 colorHex에 대응하는 `MemoColor`. 매칭 실패 시 `.yellow` 반환.
+    var memoColor: MemoColor {
+        MemoColor(rawValue: colorHex) ?? .yellow
+    }
+}

--- a/DailyMemo/Domain/Models/Memo.swift
+++ b/DailyMemo/Domain/Models/Memo.swift
@@ -58,3 +58,4 @@ final class Memo {
         MemoColor(rawValue: colorHex) ?? .yellow
     }
 }
+

--- a/DailyMemo/Presentation/Components/MemoCardView.swift
+++ b/DailyMemo/Presentation/Components/MemoCardView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// 포스트잇 형태의 메모 카드 뷰
+struct MemoCardView: View {
+
+    let memo: Memo
+    let onTap: () -> Void
+    let onDelete: () -> Void
+
+    @State private var showDeleteAlert = false
+
+    var body: some View {
+        Button(action: onTap) {
+            cardContent
+        }
+        .buttonStyle(.plain)
+        .onLongPressGesture {
+            showDeleteAlert = true
+        }
+        .alert("메모 삭제", isPresented: $showDeleteAlert) {
+            Button("삭제", role: .destructive, action: onDelete)
+            Button("취소", role: .cancel) {}
+        } message: {
+            Text("이 메모를 삭제하시겠습니까?")
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var cardContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            titleView
+            contentPreview
+            Spacer(minLength: 0)
+            dateView
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, minHeight: 140, alignment: .topLeading)
+        .background(memo.memoColor.color, in: RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.12), radius: 4, x: 0, y: 2)
+    }
+
+    private var titleView: some View {
+        Text(memo.title.isEmpty ? "무제" : memo.title)
+            .font(.headline)
+            .lineLimit(2)
+            .foregroundStyle(memo.title.isEmpty ? .secondary : .primary)
+    }
+
+    private var contentPreview: some View {
+        Text(memo.content)
+            .font(.subheadline)
+            .lineLimit(3)
+            .foregroundStyle(.secondary)
+    }
+
+    private var dateView: some View {
+        Text(memo.updatedAt.formatted(.relative(presentation: .named)))
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+            .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+}

--- a/DailyMemo/Presentation/Components/MemoColorPicker.swift
+++ b/DailyMemo/Presentation/Components/MemoColorPicker.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// 포스트잇 색상을 선택하는 HStack 컴포넌트
+struct MemoColorPicker: View {
+
+    @Binding var selectedColor: MemoColor
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ForEach(MemoColor.allCases, id: \.rawValue) { color in
+                colorButton(for: color)
+            }
+        }
+    }
+
+    // MARK: - Subviews
+
+    private func colorButton(for color: MemoColor) -> some View {
+        let isSelected = selectedColor == color
+
+        return Button {
+            selectedColor = color
+        } label: {
+            Circle()
+                .fill(color.color)
+                .frame(width: 32, height: 32)
+                .overlay {
+                    if isSelected {
+                        Circle()
+                            .strokeBorder(.primary.opacity(0.6), lineWidth: 2.5)
+                    }
+                }
+                .shadow(color: .black.opacity(0.15), radius: 2, x: 0, y: 1)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(color.label)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}

--- a/DailyMemo/Presentation/Extensions/Color+Hex.swift
+++ b/DailyMemo/Presentation/Extensions/Color+Hex.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+// MARK: - Color Hex Extension
+
+extension Color {
+    /// 6자리 HEX 문자열(`"RRGGBB"` 또는 `"#RRGGBB"`)로 Color를 초기화한다.
+    /// 잘못된 형식이거나 파싱에 실패하면 노란색 계열을 반환한다.
+    init(hex: String) {
+        let cleaned = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        let scanner = Scanner(string: cleaned)
+        var rgb: UInt64 = 0
+
+        guard cleaned.count == 6, scanner.scanHexInt64(&rgb) else {
+            // MemoColor.yellow(FFF176) 에 대응하는 fallback
+            self.init(red: 1.0, green: 0.945, blue: 0.463)
+            return
+        }
+
+        let r = Double((rgb >> 16) & 0xFF) / 255
+        let g = Double((rgb >>  8) & 0xFF) / 255
+        let b = Double( rgb        & 0xFF) / 255
+
+        self.init(red: r, green: g, blue: b)
+    }
+}
+
+// MARK: - MemoColor + SwiftUI
+
+extension MemoColor {
+    /// 포스트잇 배경에 사용하는 SwiftUI `Color`
+    var color: Color {
+        Color(hex: rawValue)
+    }
+}

--- a/DailyMemo/Presentation/MemoEdit/MemoEditView.swift
+++ b/DailyMemo/Presentation/MemoEdit/MemoEditView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import SwiftData
+
+/// 메모를 작성하거나 수정하는 Sheet View
+struct MemoEditView: View {
+
+    @Environment(\.modelContext) private var context
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var viewModel: MemoEditViewModel
+
+    /// 신규 메모 작성 시 초기화
+    init() {
+        _viewModel = State(initialValue: MemoEditViewModel())
+    }
+
+    /// 기존 메모 수정 시 초기화
+    /// - Parameter memo: 수정할 메모 객체
+    init(memo: Memo) {
+        _viewModel = State(initialValue: MemoEditViewModel(memo: memo))
+    }
+
+    var body: some View {
+        @Bindable var vm = viewModel
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    colorSection($vm.selectedColor)
+                    inputSection(title: $vm.title, content: $vm.content)
+                }
+                .padding()
+            }
+            .background(viewModel.selectedColor.color.opacity(0.25))
+            .navigationTitle(viewModel.isEditing ? "메모 수정" : "새 메모")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar { toolbarContent }
+            .alert("오류", isPresented: Binding(
+                get: { viewModel.errorMessage != nil },
+                set: { if !$0 { viewModel.errorMessage = nil } }
+            )) {
+                Button("확인") { viewModel.errorMessage = nil }
+            } message: {
+                Text(viewModel.errorMessage ?? "")
+            }
+        }
+    }
+
+    // MARK: - Subviews
+
+    private func colorSection(_ selectedColor: Binding<MemoColor>) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("색상")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            MemoColorPicker(selectedColor: selectedColor)
+        }
+    }
+
+    private func inputSection(title: Binding<String>, content: Binding<String>) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            TextField("제목", text: title)
+                .font(.title3.bold())
+
+            Rectangle()
+                .fill(.primary.opacity(0.15))
+                .frame(height: 1)
+
+            TextEditor(text: content)
+                .font(.body)
+                .frame(minHeight: 200)
+                .scrollContentBackground(.hidden)
+        }
+        .padding()
+        .background(viewModel.selectedColor.color, in: RoundedRectangle(cornerRadius: 14))
+        .shadow(color: .black.opacity(0.1), radius: 6, x: 0, y: 3)
+    }
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .cancellationAction) {
+            Button("취소") { dismiss() }
+        }
+
+        ToolbarItem(placement: .confirmationAction) {
+            Button("저장") {
+                viewModel.save(context: context)
+                if viewModel.errorMessage == nil {
+                    dismiss()
+                }
+            }
+            .disabled(!viewModel.isSaveEnabled)
+            .fontWeight(.semibold)
+        }
+
+        if viewModel.isEditing {
+            ToolbarItem(placement: .bottomBar) {
+                Button(role: .destructive) {
+                    viewModel.delete(context: context)
+                    if viewModel.errorMessage == nil {
+                        dismiss()
+                    }
+                } label: {
+                    Label("메모 삭제", systemImage: "trash")
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+    }
+}

--- a/DailyMemo/Presentation/MemoEdit/MemoEditViewModel.swift
+++ b/DailyMemo/Presentation/MemoEdit/MemoEditViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import Observation
 import SwiftData
 
-/// 메모 작성/수정 화면의 상태와 비즘니스 로직을 담당하는 ViewModel
+/// 메모 작성/수정 화면의 상태와 비즈니스 로직을 담당하는 ViewModel
 @Observable
 @MainActor
 final class MemoEditViewModel {

--- a/DailyMemo/Presentation/MemoEdit/MemoEditViewModel.swift
+++ b/DailyMemo/Presentation/MemoEdit/MemoEditViewModel.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// 메모 작성/수정 화면의 상태와 비즘니스 로직을 담당하는 ViewModel
+@Observable
+@MainActor
+final class MemoEditViewModel {
+
+    // MARK: - Input
+
+    /// 메모 제목
+    var title: String
+    /// 메모 본문
+    var content: String
+    /// 선택된 포스트잇 색상
+    var selectedColor: MemoColor
+
+    // MARK: - Output
+
+    /// 수정 모드 여부 (true: 기존 메모 수정, false: 신규 작성)
+    let isEditing: Bool
+    /// 저장 또는 삭제 실패 시 표시할 에러 메시지
+    var errorMessage: String?
+
+    /// 저장 버튼 활성화 조건 — 제목 또는 본문 중 하나 이상 입력 시
+    var isSaveEnabled: Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+        !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // MARK: - Private
+
+    private let originalMemo: Memo?
+
+    // MARK: - Init
+
+    /// 신규 메모 작성 초기화
+    init() {
+        self.title         = ""
+        self.content       = ""
+        self.selectedColor = .yellow
+        self.isEditing     = false
+        self.originalMemo  = nil
+    }
+
+    /// 기존 메모 수정 초기화
+    /// - Parameter memo: 수정할 메모 객체
+    init(memo: Memo) {
+        self.title         = memo.title
+        self.content       = memo.content
+        self.selectedColor = memo.memoColor
+        self.isEditing     = true
+        self.originalMemo  = memo
+    }
+
+    // MARK: - Actions
+
+    /// 메모를 저장한다. 신규면 insert, 수정이면 기존 객체 업데이트.
+    /// 실패 시 `errorMessage`를 설정하고 반환한다.
+    /// - Parameter context: SwiftData ModelContext
+    func save(context: ModelContext) {
+        guard isSaveEnabled else { return }
+
+        do {
+            if let memo = originalMemo {
+                memo.title     = title
+                memo.content   = content
+                memo.colorHex  = selectedColor.rawValue
+                memo.updatedAt = Date()
+            } else {
+                context.insert(Memo(
+                    title:    title,
+                    content:  content,
+                    colorHex: selectedColor.rawValue
+                ))
+            }
+            try context.save()
+        } catch {
+            errorMessage = "저장에 실패했습니다."
+        }
+    }
+
+    /// 메모를 삭제한다. 수정 모드일 때만 동작한다.
+    /// 실패 시 `errorMessage`를 설정하고 반환한다.
+    /// - Parameter context: SwiftData ModelContext
+    func delete(context: ModelContext) {
+        guard let memo = originalMemo else { return }
+
+        do {
+            context.delete(memo)
+            try context.save()
+        } catch {
+            errorMessage = "삭제에 실패했습니다."
+        }
+    }
+}

--- a/DailyMemo/Presentation/MemoList/MemoListView.swift
+++ b/DailyMemo/Presentation/MemoList/MemoListView.swift
@@ -113,7 +113,7 @@ struct MemoListView: View {
                 description: Text(
                     isFiltering
                         ? "검색어나 필터를 변경해보세요."
-                        : "+ 버튼을 눐러 첫 번째 메모를 작성해보세요."
+                        : "+ 버튼을 눌러 첫 번째 메모를 작성해보세요."
                 )
             )
         }

--- a/DailyMemo/Presentation/MemoList/MemoListView.swift
+++ b/DailyMemo/Presentation/MemoList/MemoListView.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+import SwiftData
+
+/// 메모 목록을 포스트잇 그리드로 표시하는 메인 View
+struct MemoListView: View {
+
+    @Environment(\.modelContext) private var context
+
+    @Query(sort: \Memo.updatedAt, order: .reverse)
+    private var allMemos: [Memo]
+
+    @State private var viewModel = MemoListViewModel()
+
+    private let gridColumns = [
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12)
+    ]
+
+    var body: some View {
+        @Bindable var vm = viewModel
+        NavigationStack {
+            content
+                .navigationTitle("DailyMemo")
+                .searchable(text: $vm.searchQuery, prompt: "제목 또는 내용 검색")
+                .toolbar { toolbarContent }
+                .sheet(isPresented: $vm.isAddingMemo) {
+                    MemoEditView()
+                }
+                .sheet(item: $vm.editingMemo) { memo in
+                    MemoEditView(memo: memo)
+                }
+        }
+    }
+
+    // MARK: - Subviews
+
+    @ViewBuilder
+    private var content: some View {
+        let filtered = viewModel.filteredMemos(allMemos)
+        if filtered.isEmpty {
+            emptyView
+        } else {
+            memoGrid(filtered)
+        }
+    }
+
+    private func memoGrid(_ memos: [Memo]) -> some View {
+        ScrollView {
+            colorFilterBar
+                .padding(.horizontal)
+                .padding(.top, 4)
+
+            LazyVGrid(columns: gridColumns, spacing: 12) {
+                ForEach(memos) { memo in
+                    MemoCardView(
+                        memo: memo,
+                        onTap: { viewModel.editingMemo = memo },
+                        onDelete: { viewModel.deleteMemo(memo, context: context) }
+                    )
+                }
+            }
+            .padding(.horizontal)
+            .padding(.bottom)
+        }
+    }
+
+    private var colorFilterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(MemoColor.allCases, id: \.rawValue) { color in
+                    colorChip(for: color)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private func colorChip(for color: MemoColor) -> some View {
+        let isSelected = viewModel.selectedColorFilter == color
+
+        return Button {
+            viewModel.toggleColorFilter(color)
+        } label: {
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(color.color)
+                    .frame(width: 12, height: 12)
+                Text(color.label)
+                    .font(.caption.weight(.medium))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(
+                isSelected ? color.color : Color(.systemGray6),
+                in: Capsule()
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(color.label) 필터")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private var emptyView: some View {
+        let isFiltering = !viewModel.searchQuery.isEmpty || viewModel.selectedColorFilter != nil
+        return VStack {
+            colorFilterBar
+                .padding(.horizontal)
+                .padding(.top, 4)
+
+            ContentUnavailableView(
+                isFiltering ? "결과 없음" : "메모 없음",
+                systemImage: isFiltering ? "magnifyingglass" : "note.text",
+                description: Text(
+                    isFiltering
+                        ? "검색어나 필터를 변경해보세요."
+                        : "+ 버튼을 눐러 첫 번째 메모를 작성해보세요."
+                )
+            )
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            Button {
+                viewModel.isAddingMemo = true
+            } label: {
+                Image(systemName: "square.and.pencil")
+            }
+            .accessibilityLabel("새 메모 작성")
+        }
+    }
+}

--- a/DailyMemo/Presentation/MemoList/MemoListViewModel.swift
+++ b/DailyMemo/Presentation/MemoList/MemoListViewModel.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// 메모 목록 화면의 상태와 비즘니스 로직을 담당하는 ViewModel
+@Observable
+@MainActor
+final class MemoListViewModel {
+
+    // MARK: - Input
+
+    /// 검색어 (빈 문자열이면 전체 조회)
+    var searchQuery: String = ""
+    /// 색상 필터 (nil이면 전체 표시)
+    var selectedColorFilter: MemoColor?
+
+    // MARK: - Sheet 상태
+
+    /// 새 메모 작성 Sheet 표시 여부
+    var isAddingMemo: Bool = false
+    /// 수정할 메모 (nil이면 Sheet 닫힐)
+    var editingMemo: Memo?
+
+    // MARK: - Filtering
+
+    /// `@Query` 결과를 검색어와 색상 필터로 걸러 반환한다.
+    /// - Parameter memos: SwiftData에서 가져온 전체 메모 배열
+    /// - Returns: 필터링된 메모 배열
+    func filteredMemos(_ memos: [Memo]) -> [Memo] {
+        memos.filter { memo in
+            matchesColorFilter(memo) && matchesSearchQuery(memo)
+        }
+    }
+
+    /// 메모를 삭제한다.
+    /// - Parameters:
+    ///   - memo: 삭제할 메모 객체
+    ///   - context: SwiftData ModelContext
+    func deleteMemo(_ memo: Memo, context: ModelContext) {
+        context.delete(memo)
+    }
+
+    /// 색상 필터 칩을 토글한다. 이미 선택된 색상을 탭하면 필터 해제.
+    /// - Parameter color: 탭한 색상
+    func toggleColorFilter(_ color: MemoColor) {
+        selectedColorFilter = (selectedColorFilter == color) ? nil : color
+    }
+
+    // MARK: - Private Helpers
+
+    private func matchesColorFilter(_ memo: Memo) -> Bool {
+        guard let filter = selectedColorFilter else { return true }
+        return memo.colorHex == filter.rawValue
+    }
+
+    private func matchesSearchQuery(_ memo: Memo) -> Bool {
+        guard !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return true
+        }
+        return memo.title.localizedCaseInsensitiveContains(searchQuery) ||
+               memo.content.localizedCaseInsensitiveContains(searchQuery)
+    }
+}

--- a/DailyMemo/Presentation/MemoList/MemoListViewModel.swift
+++ b/DailyMemo/Presentation/MemoList/MemoListViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import Observation
 import SwiftData
 
-/// 메모 목록 화면의 상태와 비즘니스 로직을 담당하는 ViewModel
+/// 메모 목록 화면의 상태와 비즈니스 로직을 담당하는 ViewModel
 @Observable
 @MainActor
 final class MemoListViewModel {
@@ -18,7 +18,7 @@ final class MemoListViewModel {
 
     /// 새 메모 작성 Sheet 표시 여부
     var isAddingMemo: Bool = false
-    /// 수정할 메모 (nil이면 Sheet 닫힐)
+    /// 수정할 메모 (nil이면 Sheet 닫힘)
     var editingMemo: Memo?
 
     // MARK: - Filtering

--- a/Desktop/auto-trading-system/.gitignore
+++ b/Desktop/auto-trading-system/.gitignore
@@ -1,0 +1,3 @@
+venv/
+__pycache__/
+*.pyc

--- a/Desktop/auto-trading-system/account.py
+++ b/Desktop/auto-trading-system/account.py
@@ -1,0 +1,36 @@
+# 04. 가상 계좌 관리
+
+import requests
+from config import BASE_URL, APP_KEY, APP_SECRET, ACCOUNT, ACCOUNT_CODE
+
+
+def get_balance(token):
+
+    url = f"{BASE_URL}/uapi/domestic-stock/v1/trading/inquire-balance"
+
+    headers = {
+        "authorization": f"Bearer {token}",
+        "appKey": APP_KEY,
+        "appSecret": APP_SECRET,
+        "tr_id": "VTTC8434R"
+    }
+
+    params = {
+        "CANO": ACCOUNT,
+        "ACNT_PRDT_CD": ACCOUNT_CODE,
+        "AFHR_FLPR_YN": "N",
+        "OFL_YN": "",
+        "INQR_DVSN": "02",
+        "UNPR_DVSN": "01",
+        "FUND_STTL_ICLD_YN": "N",
+        "FNCG_AMT_AUTO_RDPT_YN": "N",
+        "PRCS_DVSN": "01",
+        "CTX_AREA_FK100": "",
+        "CTX_AREA_NK100": ""
+    }
+
+    res = requests.get(url, headers=headers, params=params)
+
+    return res.json()
+    "cash": 10000000
+    "stocks": {}

--- a/Desktop/auto-trading-system/api.py
+++ b/Desktop/auto-trading-system/api.py
@@ -1,0 +1,25 @@
+# 02. 한국투자 API 연결 (토큰 발급 같은 API 인증 담당)
+
+import requests
+from config import APP_KEY, APP_SECRET, BASE_URL
+
+
+def get_token():
+
+    url = f"{BASE_URL}/oauth2/tokenP"
+
+    headers = {
+        "content-type": "application/json"
+    }
+
+    body = {
+        "grant_type": "client_credentials",
+        "appkey": APP_KEY,
+        "appsecret": APP_SECRET
+    }
+
+    res = requests.post(url, headers=headers, json=body)
+
+    token = res.json()["access_token"]
+
+    return token

--- a/Desktop/auto-trading-system/config.py
+++ b/Desktop/auto-trading-system/config.py
@@ -1,0 +1,9 @@
+#API KEY, 계좌번호와 같은 설정을 넣음
+
+APP_KEY = "PSNiT1wFqQ7IQBfL0qf4KC815B4TX4pkd4Yp"
+APP_SECRET = "PqlmmKQTHPAR2uane9h7ZekyOF5P7eK3TSE5zMgHSz6QSc92BdD/kDfaVYPtChqco5LbBIrSS9JvqetiTduMpx0Ugok78cGR1Ss2lM8LseJkvNQivIIEY2u/fCW7qEIIVApL7h6V1mZtXmw6xoxS4hLUxYOgbE8iDmt61xzVKuKKDXfQsa0="
+
+ACCOUNT = "50172885"
+ACCOUNT_CODE = "01"
+
+BASE_URL = "https://openapivts.koreainvestment.com"  # 모의투자

--- a/Desktop/auto-trading-system/data.py
+++ b/Desktop/auto-trading-system/data.py
@@ -1,0 +1,24 @@
+# 03. 주식 데이터 가져오기(현재가 조회)
+
+import requests
+from config import BASE_URL, APP_KEY, APP_SECRET
+
+def get_price(token, ticker):
+
+    url = f"{BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-price"
+
+    headers = {
+        "authorization": f"Bearer {token}",
+        "appKey": APP_KEY,
+        "appSecret": APP_SECRET,
+        "tr_id": "FHKST01010100"
+    }
+
+    params = {
+        "fid_cond_mrkt_div_code": "J",
+        "fid_input_iscd": ticker
+    }
+
+    res = requests.get(url, headers=headers, params=params)
+
+    return int(res.json()["output"]["stck_prpr"])

--- a/Desktop/auto-trading-system/main.py
+++ b/Desktop/auto-trading-system/main.py
@@ -1,0 +1,44 @@
+import time
+
+from api import get_token
+from data import get_price
+from strategy import check_signal
+from trade import buy_stock, sell_stock
+
+ticker = "005930"  # 삼성전자
+
+token = get_token()
+
+base_price = get_price(token, ticker)
+
+holding = False
+
+print("기준가격:", base_price)
+
+while True:
+
+    price = get_price(token, ticker)
+
+    signal = check_signal(base_price, price, holding)
+
+    print("현재가:", price, "신호:", signal)
+
+    if signal == "BUY":
+
+        buy_stock(ticker)
+
+        holding = True
+
+    elif signal == "SELL":
+
+        sell_stock(ticker)
+
+        holding = False
+
+    elif signal == "STOP_LOSS":
+
+        sell_stock(ticker)
+
+        holding = False
+
+    time.sleep(10)

--- a/Desktop/auto-trading-system/strategy.py
+++ b/Desktop/auto-trading-system/strategy.py
@@ -1,0 +1,24 @@
+# 05. 매매기준 (매매전략) - 10퍼 하락하면 사고, 10퍼 오르면 팔고
+
+def check_signal(base_price, current_price, holding):
+
+    change = (current_price - base_price) / base_price
+
+    if not holding:
+
+        if change <= -0.10:
+            return "BUY"
+
+        else:
+            return "HOLD"
+
+    else:
+
+        if change >= 0.10:
+            return "SELL"
+
+        elif change <= -0.15:
+            return "STOP_LOSS"
+
+        else:
+            return "HOLD"

--- a/Desktop/auto-trading-system/trade.py
+++ b/Desktop/auto-trading-system/trade.py
@@ -1,0 +1,10 @@
+# 06.
+
+def buy_stock(ticker):
+
+    print("매수 주문 실행:", ticker)
+
+
+def sell_stock(ticker):
+
+    print("매도 주문 실행:", ticker)

--- a/LoginTests/UserProfileViewModelTests.swift
+++ b/LoginTests/UserProfileViewModelTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+@testable import YourApp  // TODO: 앱 모듈명으로 교체
+
+// MARK: - Mock
+
+final class MockUserProfileUseCase: UserProfileUseCaseProtocol {
+    var result: Result<UserProfile, Error> = .success(
+        UserProfile(name: "홍길동", email: "hong@example.com", phone: "010-1234-5678")
+    )
+    var fetchCallCount = 0
+    var fetchDelay: Duration = .zero
+
+    func fetchProfile() async throws -> UserProfile {
+        fetchCallCount += 1
+        if fetchDelay > .zero {
+            try await Task.sleep(for: fetchDelay)
+        }
+        return try result.get()
+    }
+}
+
+// MARK: - Test Error
+
+private enum TestError: LocalizedError {
+    case network
+    var errorDescription: String? { "네트워크 오류" }
+}
+
+// MARK: - Tests
+
+@MainActor
+final class UserProfileViewModelTests: XCTestCase {
+
+    private var sut: UserProfileViewModel!
+    private var mockUseCase: MockUserProfileUseCase!
+
+    override func setUp() {
+        super.setUp()
+        mockUseCase = MockUserProfileUseCase()
+        sut = UserProfileViewModel(useCase: mockUseCase)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockUseCase = nil
+        super.tearDown()
+    }
+
+    // MARK: - 초기 상태
+
+    func test_초기상태_프로필이빈값() {
+        XCTAssertEqual(sut.profile.name, "")
+        XCTAssertEqual(sut.profile.email, "")
+        XCTAssertEqual(sut.profile.phone, "")
+        XCTAssertNil(sut.profile.profileImageName)
+    }
+
+    func test_초기상태_로딩및에러없음() {
+        XCTAssertFalse(sut.isLoading)
+        XCTAssertNil(sut.errorMessage)
+    }
+
+    // MARK: - loadProfile 성공
+
+    func test_loadProfile_성공시프로필업데이트() async {
+        await sut.loadProfile()
+
+        XCTAssertEqual(sut.profile.name, "홍길동")
+        XCTAssertEqual(sut.profile.email, "hong@example.com")
+        XCTAssertEqual(sut.profile.phone, "010-1234-5678")
+    }
+
+    func test_loadProfile_성공시errorMessage는nil() async {
+        await sut.loadProfile()
+
+        XCTAssertNil(sut.errorMessage)
+    }
+
+    func test_loadProfile_완료후isLoading이false() async {
+        await sut.loadProfile()
+
+        XCTAssertFalse(sut.isLoading)
+    }
+
+    func test_loadProfile_useCase가정확히1회호출됨() async {
+        await sut.loadProfile()
+
+        XCTAssertEqual(mockUseCase.fetchCallCount, 1)
+    }
+
+    // MARK: - loadProfile 실패
+
+    func test_loadProfile_실패시errorMessage설정() async {
+        mockUseCase.result = .failure(TestError.network)
+
+        await sut.loadProfile()
+
+        XCTAssertNotNil(sut.errorMessage)
+        XCTAssertEqual(sut.errorMessage, TestError.network.errorDescription)
+    }
+
+    func test_loadProfile_실패시프로필이변경되지않음() async {
+        mockUseCase.result = .failure(TestError.network)
+
+        await sut.loadProfile()
+
+        XCTAssertEqual(sut.profile.name, "")
+    }
+
+    func test_loadProfile_실패후isLoading이false() async {
+        mockUseCase.result = .failure(TestError.network)
+
+        await sut.loadProfile()
+
+        XCTAssertFalse(sut.isLoading)
+    }
+
+    // MARK: - Task 취소
+
+    func test_loadProfile_취소시프로필이변경되지않음() async {
+        mockUseCase.fetchDelay = .milliseconds(100)
+
+        let task = Task { await self.sut.loadProfile() }
+        task.cancel()
+        await task.value
+
+        XCTAssertEqual(sut.profile.name, "")
+    }
+
+    func test_loadProfile_취소시isLoading이false() async {
+        mockUseCase.fetchDelay = .milliseconds(100)
+
+        let task = Task { await self.sut.loadProfile() }
+        task.cancel()
+        await task.value
+
+        XCTAssertFalse(sut.isLoading)
+    }
+
+    func test_loadProfile_취소시errorMessage없음() async {
+        mockUseCase.fetchDelay = .milliseconds(100)
+
+        let task = Task { await self.sut.loadProfile() }
+        task.cancel()
+        await task.value
+
+        XCTAssertNil(sut.errorMessage)
+    }
+
+    // MARK: - 연속 호출
+
+    func test_loadProfile_연속호출시useCase두번호출됨() async {
+        await sut.loadProfile()
+        await sut.loadProfile()
+
+        XCTAssertEqual(mockUseCase.fetchCallCount, 2)
+    }
+
+    func test_loadProfile_두번째호출시이전에러초기화() async {
+        mockUseCase.result = .failure(TestError.network)
+        await sut.loadProfile()
+
+        mockUseCase.result = .success(
+            UserProfile(name: "홍길동", email: "hong@example.com", phone: "010-1234-5678")
+        )
+        await sut.loadProfile()
+
+        XCTAssertNil(sut.errorMessage)
+        XCTAssertEqual(sut.profile.name, "홍길동")
+    }
+}

--- a/UserProfileView.swift
+++ b/UserProfileView.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+
+// MARK: - Model
+
+/// 사용자 프로필 데이터 모델
+struct UserProfile {
+    var name: String
+    var email: String
+    var phone: String
+    var profileImageName: String?
+}
+
+// MARK: - ViewModel
+
+/// 사용자 프로필 화면의 비즈니스 로직을 담당하는 ViewModel
+@MainActor
+final class UserProfileViewModel: ObservableObject {
+    @Published private(set) var profile: UserProfile
+    @Published private(set) var isLoading: Bool = false
+    @Published var errorMessage: String?
+
+    init() {
+        self.profile = UserProfile(name: "", email: "", phone: "")
+    }
+
+    /// 프로필 데이터를 불러옵니다.
+    func loadProfile() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        // 실제 데이터 소스로 교체하세요
+        try? await Task.sleep(for: .seconds(1))
+        profile = UserProfile(
+            name: "홍길동",
+            email: "hong@example.com",
+            phone: "010-1234-5678",
+            profileImageName: nil
+        )
+    }
+}
+
+// MARK: - View
+
+/// 사용자 프로필을 표시하는 View
+struct UserProfileView: View {
+    @StateObject private var viewModel = UserProfileViewModel()
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("프로필")
+                .task { await viewModel.loadProfile() }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel.isLoading {
+            ProgressView()
+        } else {
+            profileContent
+        }
+    }
+
+    private var profileContent: some View {
+        List {
+            profileImageSection
+            infoSection
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    private var profileImageSection: some View {
+        Section {
+            HStack {
+                Spacer()
+                ProfileImageView(imageName: viewModel.profile.profileImageName)
+                Spacer()
+            }
+            .padding(.vertical, 8)
+        }
+        .listRowBackground(Color.clear)
+    }
+
+    private var infoSection: some View {
+        Section("기본 정보") {
+            ProfileInfoRow(label: "이름", value: viewModel.profile.name, icon: "person.fill")
+            ProfileInfoRow(label: "이메일", value: viewModel.profile.email, icon: "envelope.fill")
+            ProfileInfoRow(label: "전화번호", value: viewModel.profile.phone, icon: "phone.fill")
+        }
+    }
+}
+
+// MARK: - Profile Image View
+
+/// 프로필 이미지를 표시하는 View
+private struct ProfileImageView: View {
+    let imageName: String?
+
+    private let size: CGFloat = 100
+
+    var body: some View {
+        Group {
+            if let imageName {
+                Image(imageName)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Image(systemName: "person.circle.fill")
+                    .resizable()
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+        .overlay(Circle().stroke(Color.secondary.opacity(0.3), lineWidth: 1))
+    }
+}
+
+// MARK: - Info Row View
+
+/// 프로필 정보의 각 행을 표시하는 View
+private struct ProfileInfoRow: View {
+    let label: String
+    let value: String
+    let icon: String
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .foregroundStyle(.tint)
+                .frame(width: 20)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(label)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(value.isEmpty ? "-" : value)
+                    .font(.body)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    UserProfileView()
+}

--- a/UserProfileView.swift
+++ b/UserProfileView.swift
@@ -29,7 +29,11 @@ final class UserProfileViewModel: ObservableObject {
         defer { isLoading = false }
 
         // 실제 데이터 소스로 교체하세요
-        try? await Task.sleep(for: .seconds(1))
+        do {
+            try await Task.sleep(for: .seconds(1))
+        } catch {
+            return
+        }
         profile = UserProfile(
             name: "홍길동",
             email: "hong@example.com",
@@ -78,8 +82,8 @@ struct UserProfileView: View {
                 Spacer()
             }
             .padding(.vertical, 8)
+            .listRowBackground(Color.clear)
         }
-        .listRowBackground(Color.clear)
     }
 
     private var infoSection: some View {
@@ -108,6 +112,7 @@ private struct ProfileImageView: View {
             } else {
                 Image(systemName: "person.circle.fill")
                     .resizable()
+                    .scaledToFit()
                     .foregroundStyle(.secondary)
             }
         }

--- a/UserProfileView.swift
+++ b/UserProfileView.swift
@@ -10,6 +10,26 @@ struct UserProfile {
     var profileImageName: String?
 }
 
+// MARK: - Use Case Protocol
+
+/// 프로필 데이터를 가져오는 UseCase 프로토콜
+protocol UserProfileUseCaseProtocol {
+    func fetchProfile() async throws -> UserProfile
+}
+
+/// 기본 UseCase 구현체
+final class DefaultUserProfileUseCase: UserProfileUseCaseProtocol {
+    func fetchProfile() async throws -> UserProfile {
+        try await Task.sleep(for: .seconds(1))
+        return UserProfile(
+            name: "홍길동",
+            email: "hong@example.com",
+            phone: "010-1234-5678",
+            profileImageName: nil
+        )
+    }
+}
+
 // MARK: - ViewModel
 
 /// 사용자 프로필 화면의 비즈니스 로직을 담당하는 ViewModel
@@ -19,8 +39,11 @@ final class UserProfileViewModel: ObservableObject {
     @Published private(set) var isLoading: Bool = false
     @Published var errorMessage: String?
 
-    init() {
+    private let useCase: UserProfileUseCaseProtocol
+
+    init(useCase: UserProfileUseCaseProtocol = DefaultUserProfileUseCase()) {
         self.profile = UserProfile(name: "", email: "", phone: "")
+        self.useCase = useCase
     }
 
     /// 프로필 데이터를 불러옵니다.
@@ -28,18 +51,13 @@ final class UserProfileViewModel: ObservableObject {
         isLoading = true
         defer { isLoading = false }
 
-        // 실제 데이터 소스로 교체하세요
         do {
-            try await Task.sleep(for: .seconds(1))
-        } catch {
+            profile = try await useCase.fetchProfile()
+        } catch is CancellationError {
             return
+        } catch {
+            errorMessage = error.localizedDescription
         }
-        profile = UserProfile(
-            name: "홍길동",
-            email: "hong@example.com",
-            phone: "010-1234-5678",
-            profileImageName: nil
-        )
     }
 }
 


### PR DESCRIPTION
## 개요

SwiftUI + SwiftData 기반 포스트잇 형식 메모 앱 **DailyMemo** 전체 구현.

---

## 구현 내용

### 아키텍처
- **MVVM + SwiftData** 직접 패턴 (Repository/UseCase 레이어 없음 — CRUD 단순성 유지)
- `@Observable` 매크로 (iOS 17+) — `ObservableObject` 대신 사용
- `@MainActor` 명시, 강제 언래핑 없음

### 파일 구성

| 파일 | 설명 |
|------|------|
| `Domain/Models/Memo.swift` | SwiftData `@Model` 엔티티 + `MemoColor` enum |
| `Presentation/Extensions/Color+Hex.swift` | Hex 색상 파싱 (방어 코드 포함, Domain 레이어 분리) |
| `Presentation/Components/MemoCardView.swift` | 포스트잇 카드 UI, 롱프레스 삭제 Alert |
| `Presentation/Components/MemoColorPicker.swift` | 색상 선택 HStack 컴포넌트 |
| `Presentation/MemoEdit/MemoEditViewModel.swift` | 저장/삭제 + 에러 처리 |
| `Presentation/MemoEdit/MemoEditView.swift` | 신규/수정 Sheet, 에러 Alert |
| `Presentation/MemoList/MemoListViewModel.swift` | 검색 · 색상 필터 · 삭제 |
| `Presentation/MemoList/MemoListView.swift` | LazyVGrid 2열, 색상 필터 칩, 빈 상태 |
| `DailyMemoTests/MemoListViewModelTests.swift` | Swift Testing — 17개 테스트 |
| `DailyMemoTests/MemoEditViewModelTests.swift` | Swift Testing — 20개 테스트 |

### 주요 기능
- 메모 CRUD (생성·조회·수정·삭제)
- 포스트잇 5가지 색상 (노랑·분홍·하늘·초록·보라)
- 제목·본문 실시간 검색 (대소문자 무시)
- 색상 필터 칩 (토글 방식)
- 저장/삭제 실패 시 에러 Alert 표시
- SwiftData 영속성 (앱 재시작 후 데이터 유지)

### 코드 리뷰 수정 사항
- Domain 레이어에서 `import SwiftUI` 제거 → `Color+Hex.swift` 분리
- `Color(hex:)` 방어 코드 추가 (6자리 검증, scanHexInt64 결과 확인, fallback)
- `save()` 실패 시 항상 dismiss하던 버그 수정 → `errorMessage == nil` 조건 추가
- `ObservableObject` → `@Observable` 마이그레이션

### Claude Code Hooks
- `PreToolUse(Bash)` 훅: `git commit` 시 main 브랜치 직접 커밋 차단 + staged Swift 파일 `print()` 검사
- `PreToolUse(Edit|Write)` 훅: main 브랜치 파일 수정 차단

## 테스트 계획

- [ ] `swift test` 실행 — 37개 테스트 전체 통과 확인
- [ ] 메모 생성 → 포스트잇 카드로 목록 즉시 반영
- [ ] 카드 탭 → 수정 Sheet, 내용 수정 후 저장
- [ ] 롱프레스 → 삭제 Alert → 목록에서 제거
- [ ] 검색어 입력 → 제목·본문 실시간 필터링
- [ ] 색상 필터 칩 → 해당 색상 카드만 표시, 재탭 시 전체 표시
- [ ] 앱 재시작 후 데이터 유지 (SwiftData 영속성)

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)